### PR TITLE
Fix readme to match current cookbook logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ template:
     -A FWR -p tcp -m tcp --dport 80 -j ACCEPT
 
 This would go in the cookbook,
-`httpd/templates/default/port_http.erb`. Then to use it in
+`httpd/templates/default/http.erb`. Then to use it in
 `recipe[httpd]`:
 
     iptables_rule "http"


### PR DESCRIPTION
Doesn't expect the rule template name to start with `port_` anymore.
