### PR TITLE
COOK-1883 : Cookbook iptables has unstated perl requirement

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@
 #
 
 package "iptables" 
+package "perl"
 
 execute "rebuild-iptables" do
   command "/usr/sbin/rebuild-iptables"


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1883

The cookbook "iptables" creates and executes the /usr/sbin/rebuild-iptables perl script. The cookbook, however, doesn't ensure that perl is installed. For systems that didn't happen to already have perl installed, the iptables cookbook fails with the somewhat confusing error message :

`[2012-11-11T08:36:30-08:00] FATAL: Errno::ENOENT: execute[rebuild-iptables] (iptables::default line 22) had an error: Errno::ENOENT: No such file or directory - /usr/sbin/rebuild-iptables`

I've fixed this bug by adding the perl requirement and tested it. Feel free to test and merge my pull request
