### PR TITLE
[COOK-4411] Ensure iptables general file ends with newline

### DIFF
--- a/files/default/rebuild-iptables
+++ b/files/default/rebuild-iptables
@@ -69,6 +69,7 @@ sub snat {
     while (<SNAT>) {
       $data = $data . $_;
     }
+    $data = $data . "\n";
     close(SNAT);
   }
   return $data;


### PR DESCRIPTION
If the iptables.snat file is not terminated with a newline, the
iptables/general file generated by rebuild-iptables will error
out with the message "iptables-restore: no command specified"
