### PR TITLE
Update `rebuild-iptables` script

### DIFF
--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -93,6 +93,21 @@ end
             'OUTPUT'      => 'ACCEPT [0,0]'
         },
         :rules => [],
+    },
+    :raw => {
+        :chains => {
+            'PREROUTING'  => 'ACCEPT [0,0]',
+            'OUTPUT'      => 'ACCEPT [0,0]'
+        },
+        :rules => [],
+    },
+    :security => {
+        :chains => {
+            'INPUT'   => 'ACCEPT [0,0]',
+            'FORWARD' => 'ACCEPT [0,0]',
+            'OUTPUT'  => 'ACCEPT [0,0]'
+        },
+        :rules => []
     }
 }
 


### PR DESCRIPTION
This cookbook [recently began using](https://github.com/opscode-cookbooks/iptables/commit/a76480f21e0bb019a2aac7af0896d3da08ae789c) my rebuild script in place of the old Perl version. This PR brings in the latest changes from https://github.com/phlipper/rebuild-iptables.
