### PR TITLE
Multi-table support

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ directory "/etc/iptables.d" do
 end
 
 template "/usr/sbin/rebuild-iptables" do
-  source "rebuild-iptables.erb"
+  source "rebuild-iptables.rb.erb"
   mode 0755
   variables(
     :hashbang => ::File.exist?('/usr/bin/ruby') ? '/usr/bin/ruby' : '/opt/chef/embedded/bin/ruby'

--- a/templates/default/rebuild-iptables.rb.erb
+++ b/templates/default/rebuild-iptables.rb.erb
@@ -26,8 +26,12 @@ TEMPLATE_PATH = "/etc/iptables.d"
 # Read in a file, processing includes as required.
 def read_iptables(file, table = :filter)
   file = File.join(TEMPLATE_PATH, file) unless File.dirname(file) =~ /iptables\.d/
-  rule = File.readlines(file).map{ |line| line.chomp }
-  rule.each do |line|
+  rules = File.readlines(file).map{ |line| line.chomp }
+  if rules.first.match(/^\*/)
+     table = rules.shift[1..-1].to_sym
+  end
+
+  rules.each do |line|
     if line =~ /^\s*include\s+(\S+)$/
       read_iptables($1, table)
     elsif line =~ /^\s*\*([a-z]+)\s*$/


### PR DESCRIPTION
When each file is read from rebuild-iptables, the first line is checked for a  table name (such as *nat).   If a name is found the rules in the file are added to that table.


