### PR TITLE
Adding Support for CentOS/RHEL 7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,10 @@
 # limitations under the License.
 #
 
-package "iptables" 
+package "iptables"
+if platform_family?("rhel") && node["platform_version"].to_i == 7
+  package "iptables-services"
+end
 
 execute "rebuild-iptables" do
   command "/usr/sbin/rebuild-iptables"


### PR DESCRIPTION
New version also requires the `iptables-services` package.
