### PR TITLE
use_inline_resources breaks on Chef 10

### DIFF
--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -22,7 +22,7 @@ def whyrun_supported?
   true
 end
 
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 action :enable do
   execute 'rebuild-iptables' do


### PR DESCRIPTION
Use 'use_inline_resources'  only if it exists (which it doesn't on Chef <0.11).