### PR TITLE
fix the run list for the rules kitchen test suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,7 @@ suites:
   - name: rules
     run_list:
       - recipe[iptables::default]
-      - recipe[iptables_secure::default]
+      - recipe[iptables_test::default]
   - name: disabled
     run_list:
       - recipe[iptables::disabled]


### PR DESCRIPTION
This will probably still fail because of the problems with chef-cookbooks/compat_resource#37
But at least now it's trying to run the correct recipe