### PR TITLE
Fix iptables::disabled to install the correct packages on RHEL 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Installs iptables and provides a custom resource for adding and removing iptable
 ### default
 The default recipe will install iptables and provides a ruby script (installed in `/usr/sbin/rebuild-iptables`) to manage rebuilding firewall rules from files dropped off in `/etc/iptables.d`.
 
+### disabled
+The disabled recipe will install iptables, disable the `iptables` service (on RHEL platforms), and delete the rules directory `/etc/iptables.d`.
+
 ## Attributes
  `default['iptables']['iptables_sysconfig']` and `default['iptables']['iptables_sysconfig']` are hashes that are used to template /etc/sysconfig/iptables-config and /etc/sysconfig/ip6tables-config. The keys must be upper case and any key / value pair included will be added to the config file.
 

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: iptables
-# Recipe:: default
+# Recipe:: _package
 #
 # Copyright 2008-2016, Chef Software, Inc.
 #
@@ -17,17 +17,8 @@
 # limitations under the License.
 #
 
-include_recipe 'iptables::_package'
-
-service 'iptables' do
-  action [:disable, :stop]
-  supports status: true, start: true, stop: true, restart: true
-  only_if { node['platform_family'] == 'rhel' }
-end
-
-# Necessary so that if iptables::disable is used and then later
-# it is re-enabled without any rules changes, the templates will run the rebuilt script
-directory '/etc/iptables.d' do
-  action :delete
-  recursive true
+if platform_family?('rhel') && node['platform_version'].to_i == 7
+  package 'iptables-services'
+else
+  package 'iptables'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,11 +17,7 @@
 # limitations under the License.
 #
 
-if platform_family?('rhel') && node['platform_version'].to_i == 7
-  package 'iptables-services'
-else
-  package 'iptables'
-end
+include_recipe 'iptables::_package'
 
 execute 'rebuild-iptables' do
   command '/usr/sbin/rebuild-iptables'

--- a/spec/unit/recipes/disabled_spec.rb
+++ b/spec/unit/recipes/disabled_spec.rb
@@ -3,17 +3,29 @@ require 'spec_helper'
 describe 'iptables::disabled' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'installs package iptables' do
-    expect(chef_run).to install_package('iptables')
-  end
-
   it 'deletes /etc/iptables.d directory' do
     expect(chef_run).to delete_directory('/etc/iptables.d')
+  end
+
+  context 'debian' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
+    end
+
+    it 'installs package iptables' do
+      expect(chef_run).to install_package('iptables')
+      expect(chef_run).to_not install_package('iptables-services')
+    end
   end
 
   context 'rhel 7' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0').converge(described_recipe)
+    end
+
+    it 'should install iptables-services' do
+      expect(chef_run).to install_package('iptables-services')
+      expect(chef_run).to_not install_package('iptables')
     end
 
     it 'disables and stops iptables service' do

--- a/test/integration/disabled/serverspec/disabled_spec.rb
+++ b/test/integration/disabled/serverspec/disabled_spec.rb
@@ -4,6 +4,7 @@ set :backend, :exec
 
 if os[:family] == 'redhat'
   describe service('iptables') do
+    it { should be_installed }
     it { should_not be_enabled }
     it { should_not be_running }
   end


### PR DESCRIPTION
The `iptables::disabled` recipe was still installing `iptables` on RHEL 7 instead of `iptables-service`. 

These changes address the comments I made in #12 and on commit 53ecf956e8866fd0980b21d5a82e3493bab02341