### PR TITLE
install logic modification for rhel rebuild script

### DIFF
--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -55,6 +55,7 @@ def install_redhat(data)
   Dir.mkdir("/etc/iptables") unless File.directory?("/etc/iptables")
   write_iptables("/etc/iptables/general", data)
   system("/sbin/iptables-restore < /etc/iptables/general")
+  system("cp /etc/iptables/general /etc/sysconfig/iptables")
 end
 
 # Install iptables on a Debian system. Takes the new iptables data.

--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -52,8 +52,9 @@ end
 
 # Install iptables on a Red Hat system. Takes the new iptables data.
 def install_redhat(data)
-  write_iptables("/etc/sysconfig/iptables", data)
-  system("/sbin/service", "iptables", "restart")
+  Dir.mkdir("/etc/iptables") unless File.directory?("/etc/iptables")
+  write_iptables("/etc/iptables/general", data)
+  system("/sbin/iptables-restore < /etc/iptables/general")
 end
 
 # Install iptables on a Debian system. Takes the new iptables data.


### PR DESCRIPTION
This pull request modifies the install logic for rhel platforms in the `rebuild-iptables` scripts. It now uses `iptables-restore` to build the rules instead of restarting the service, which is preferred. If the `/sbin/service iptables restart` fails, it will essentially flush all of your rules.  `iptables-restore` will not execute successfully if there is a format or syntax error, and it will not reset your rules on a failure. 

This PR also adds a change that copies the new rule template to the default iptables location at `/etc/sysconfig/iptables`. When iptables restarts, it builds the rules from this location. Under the current configuration, rules may be overwritten if the service unexpectedly restarted. This change will ensure that an unexpected iptables restart will not flush your rules because it built from an empty template file. 
