### PR TITLE
refactor rebuild-iptables script

### DIFF
--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -50,19 +50,12 @@ def write_iptables(file, data)
   File.rename("#{file}.new", file)
 end
 
-# Install iptables on a Red Hat system. Takes the new iptables data.
-def install_redhat(data)
+# Install iptables on a Red Hat or Debian system. Takes the new iptables data.
+def install_rules(data)
   Dir.mkdir("/etc/iptables") unless File.directory?("/etc/iptables")
   write_iptables("/etc/iptables/general", data)
   system("/sbin/iptables-restore < /etc/iptables/general")
   system("cp /etc/iptables/general /etc/sysconfig/iptables")
-end
-
-# Install iptables on a Debian system. Takes the new iptables data.
-def install_debian(data)
-  Dir.mkdir("/etc/iptables") unless File.directory?("/etc/iptables")
-  write_iptables("/etc/iptables/general", data)
-  system("/sbin/iptables-restore < /etc/iptables/general")
 end
 
 ##############################################################################
@@ -135,12 +128,9 @@ iptables_rules = ""
   end
 end
 
-if File.exist?("/etc/debian_version")
-  install_debian(iptables_rules)
-elsif File.exist?("/etc/redhat-release")
-  install_redhat(iptables_rules)
-elsif File.exist?("/etc/system-release") # Amazon Linux
-  install_redhat(iptables_rules)
+system_files = %w(/etc/debian_version /etc/redhat-release /etc/system-release)
+if system_files.any? { |file| File.exist?(file) }
+  install_rules(iptables_rules)
 else
   raise "#{$0}: cannot figure out whether this is Red Hat or Debian\n";
 end


### PR DESCRIPTION
In #52 I mentioned that modifying the Red Hat install method would allow for refactoring of both install methods in the `rebuild-iptables` script. This pull request consolidates the methods and simplifies the conditional at the end of the script. 