### PR TITLE
Set path to system ruby in an attribute so that it can be overriden

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,3 +37,5 @@ default['iptables']['ip6tables_sysconfig'] = {
   'IP6TABLES_STATUS_VERBOSE' => 'no',
   'IP6TABLES_STATUS_LINENUMBERS' => 'yes'
 }
+
+default['iptables']['system_ruby'] = '/usr/bin/ruby'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+system_ruby = node['iptables']['system_ruby']
+
 include_recipe 'iptables::_package'
 
 execute 'rebuild-iptables' do
@@ -32,7 +34,7 @@ template '/usr/sbin/rebuild-iptables' do
   source 'rebuild-iptables.erb'
   mode '0755'
   variables(
-    hashbang: ::File.exist?('/usr/bin/ruby') ? '/usr/bin/ruby' : '/opt/chef/embedded/bin/ruby'
+    hashbang: ::File.exist?(system_ruby) ? system_ruby : '/opt/chef/embedded/bin/ruby'
   )
 end
 


### PR DESCRIPTION
### Description

Allows users to override the system ruby path if ruby is installed into a non standard location and Chef has been installed without an embedded ruby (eg. from the Gem)

### Issues Resolved

#18 

### Check List
- [y ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ n] New functionality includes testing.
- [ n] New functionality has been documented in the README if applicable
- [ y] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


