### PR TITLE
fix so rebuild-iptables only runs once

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,3 +45,12 @@ suites:
           IPTABLES_STATUS_VERBOSE: 'yes'
         ip6tables_sysconfig:
           IPTABLES_STATUS_VERBOSE: 'yes'
+  - name: nested
+    run_list:
+      - recipe[iptables_test::nested]
+    attributes:
+      iptables:
+        iptables_sysconfig:
+          IPTABLES_STATUS_VERBOSE: 'yes'
+        ip6tables_sysconfig:
+          IPTABLES_STATUS_VERBOSE: 'yes'

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -26,9 +26,12 @@ property :lines, kind_of: String, default: nil
 default_action :enable
 
 action :enable do
-  execute 'rebuild-iptables' do
-    command '/usr/sbin/rebuild-iptables'
-    action :nothing
+  # ensure we have execute[rebuild-iptables] in the outer run_context
+  with_run_context :root do
+    find_resource(:execute, 'rebuild-iptables') do
+      command '/usr/sbin/rebuild-iptables'
+      action :nothing
+    end
   end
 
   if lines.nil?
@@ -51,9 +54,12 @@ action :enable do
 end
 
 action :disable do
-  execute 'rebuild-iptables' do
-    command '/usr/sbin/rebuild-iptables'
-    action :nothing
+  # ensure we have execute[rebuild-iptables] in the outer run_context
+  with_run_context :root do
+    find_resource(:execute, 'rebuild-iptables') do
+      command '/usr/sbin/rebuild-iptables'
+      action :nothing
+    end
   end
 
   file "/etc/iptables.d/#{new_resource.name}" do

--- a/test/fixtures/cookbooks/iptables_test/recipes/nested.rb
+++ b/test/fixtures/cookbooks/iptables_test/recipes/nested.rb
@@ -1,6 +1,5 @@
 include_recipe 'iptables::default'
 
-
 iptables_rule 'sshd' do
   lines '-A FWR -p tcp -m tcp --dport 22 -j ACCEPT'
 end

--- a/test/fixtures/cookbooks/iptables_test/recipes/nested.rb
+++ b/test/fixtures/cookbooks/iptables_test/recipes/nested.rb
@@ -1,0 +1,14 @@
+include_recipe 'iptables::default'
+
+
+iptables_rule 'sshd' do
+  lines '-A FWR -p tcp -m tcp --dport 22 -j ACCEPT'
+end
+
+nested 'httpd' do
+  lines '-A FWR -p tcp -m tcp --dport 80 -j ACCEPT'
+end
+
+doubly_nested 'https' do
+  lines '-A FWR -p tcp -m tcp --dport 443 -j ACCEPT'
+end

--- a/test/fixtures/cookbooks/iptables_test/resources/doubly_nested.rb
+++ b/test/fixtures/cookbooks/iptables_test/resources/doubly_nested.rb
@@ -1,0 +1,19 @@
+provides :doubly_nested
+resource_name :doubly_nested
+
+property :name, kind_of: String, name_attribute: true
+property :source, kind_of: String, default: nil
+property :cookbook, kind_of: String, default: nil
+property :variables, kind_of: Hash, default: {}
+property :lines, kind_of: String, default: nil
+
+default_action :doit
+
+action :doit do
+  nested new_resource.name do
+    source new_resource.source
+    cookbook new_resource.cookbook
+    variables new_resource.variables
+    lines new_resource.lines
+  end
+end

--- a/test/fixtures/cookbooks/iptables_test/resources/nested.rb
+++ b/test/fixtures/cookbooks/iptables_test/resources/nested.rb
@@ -1,0 +1,19 @@
+provides :nested
+resource_name :nested
+
+property :name, kind_of: String, name_attribute: true
+property :source, kind_of: String, default: nil
+property :cookbook, kind_of: String, default: nil
+property :variables, kind_of: Hash, default: {}
+property :lines, kind_of: String, default: nil
+
+default_action :doit
+
+action :doit do
+  iptables_rule new_resource.name do
+    source new_resource.source
+    cookbook new_resource.cookbook
+    variables new_resource.variables
+    lines new_resource.lines
+  end
+end

--- a/test/integration/nested/serverspec/default_spec.rb
+++ b/test/integration/nested/serverspec/default_spec.rb
@@ -19,10 +19,10 @@ end
 
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
-    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
   end
 
   describe file('/etc/sysconfig/ip6tables-config') do
-    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
   end
 end

--- a/test/integration/nested/serverspec/default_spec.rb
+++ b/test/integration/nested/serverspec/default_spec.rb
@@ -1,0 +1,28 @@
+require 'serverspec'
+
+set :backend, :exec
+
+# the disable recipe will delete this, but the install should add it back
+describe file('/etc/iptables.d') do
+  it { should be_directory }
+end
+
+describe file('/usr/sbin/rebuild-iptables') do
+  it { should exist }
+end
+
+if %w(debian ubuntu).include?(os[:family])
+  describe file('/etc/network/if-pre-up.d/iptables_load') do
+    it { should exist }
+  end
+end
+
+if %w(redhat fedora).include?(os[:family])
+  describe file('/etc/sysconfig/iptables-config') do
+    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+  end
+
+  describe file('/etc/sysconfig/ip6tables-config') do
+    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+  end
+end

--- a/test/integration/nested/serverspec/rules_spec.rb
+++ b/test/integration/nested/serverspec/rules_spec.rb
@@ -1,0 +1,15 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe iptables do
+  it { should have_rule('-A FWR -p tcp -m tcp --dport 22 -j ACCEPT') }
+  it { should have_rule('-A FWR -p tcp -m tcp --dport 80 -j ACCEPT') }
+  it { should have_rule('-A FWR -p tcp -m tcp --dport 443 -j ACCEPT') }
+end
+
+%w{sshd httpd https}.each do |file|
+  describe file("/etc/iptables.d/#{file}") do
+    it { should exist }
+  end
+end

--- a/test/integration/nested/serverspec/rules_spec.rb
+++ b/test/integration/nested/serverspec/rules_spec.rb
@@ -8,7 +8,7 @@ describe iptables do
   it { should have_rule('-A FWR -p tcp -m tcp --dport 443 -j ACCEPT') }
 end
 
-%w{sshd httpd https}.each do |file|
+%w(sshd httpd https).each do |file|
   describe file("/etc/iptables.d/#{file}") do
     it { should exist }
   end


### PR DESCRIPTION
closes #61 

uses the fact that resource notifications now bubble up to outer run_context
also uses the new resource_collection editing features
both of those features should have been in compat_resource for some time now

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>