### PR TITLE
[GH-69] - clearing out iptables rule files on RHEL and flushing ruleset

### DIFF
--- a/recipes/disabled.rb
+++ b/recipes/disabled.rb
@@ -33,6 +33,14 @@ directory '/etc/iptables.d' do
   notifies :run, 'execute[iptablesFlush]', :immediately
 end
 
+%w( /etc/sysconfig/iptables /etc/sysconfig/iptables.fallback ).each do |f|
+  file f do
+    content '# iptables rules files cleared by chef via iptables::disabled'
+    only_if { node['platform_family'] == 'rhel' }
+    notifies :run, 'execute[iptablesFlush]', :immediately
+  end
+end
+
 # Flush and delete iptables rules
 execute 'iptablesFlush' do
   command 'iptables -F'

--- a/test/integration/disabled/serverspec/disabled_spec.rb
+++ b/test/integration/disabled/serverspec/disabled_spec.rb
@@ -14,3 +14,13 @@ end
 describe file('/etc/iptables.d') do
   it { should_not be_directory }
 end
+
+# some RHEL/CentOS versions use these files to persist rules. disable recipe
+# "clears" these files out.
+%w( /etc/sysconfig/iptables /etc/sysconfig/iptables.fallback ).each do |file|
+  describe file(file) do
+    it { should exist }
+    it { should be_file }
+    its(:content) { should match(/^# iptables rules files cleared by chef via iptables::disabled$/) }
+  end
+end


### PR DESCRIPTION
### Description

* clears out /etc/sysconfig/iptables and /etc/sysconfig/iptables.fallback on
  RHEL family platforms. If these files are updated it triggers and iptables
  flush.
* Adds tests around the above files

### Issues Resolved

https://github.com/chef-cookbooks/iptables/issues/69

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
