### PR TITLE
Update metadata to require Chef 12.10+ due to use of with_run_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # iptables Cookbook CHANGELOG
 This file is used to list changes made in each version of the iptables cookbook.
 
+## 4.0.1 (2017-03-29)
+- Update metadata to require Chef 12.10+ due to use of with_run_context 
+
 ## 4.0.0 (2017-02-27)
 
 - Remove EOL platforms from testing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installs iptables and provides a custom resource for adding and removing iptable
 
 ### Chef
 
-- Chef 12.5+
+- Chef 12.10+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs the iptables daemon and provides a LWRP for managing rules'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.0'
+version '4.0.1'
 
 recipe 'default', 'Installs iptables and sets up .d style config directory of iptables rules'
 recipe 'disabled', 'Disables iptables'
@@ -15,4 +15,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/iptables'
 issues_url 'https://github.com/chef-cookbooks/iptables/issues'
-chef_version '>= 12.5' if respond_to?(:chef_version)
+chef_version '>= 12.10' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Update metadata to require Chef 12.10+ due to use of with_run_context

### Issues Resolved

Issue #73 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
