### PR TITLE
specify optional table property for use with lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ iptables_rule 'http_8080' do
 end
 ```
 
-To create a rule without using a template resource use the `lines` property:
+To create a rule without using a template resource use the `lines` property (you can optionally specify `table` when using `lines`):
 
 ```ruby
 iptables_rule 'http_8080' do
   lines '-A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080'
+  table :nat
 end
 ```
 

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -22,6 +22,7 @@ property :source, kind_of: String, default: nil
 property :cookbook, kind_of: String, default: nil
 property :variables, kind_of: Hash, default: {}
 property :lines, kind_of: String, default: nil
+property :table, kind_of: Symbol, default: nil
 
 action :enable do
   # ensure we have execute[rebuild-iptables] in the outer run_context
@@ -42,6 +43,7 @@ action :enable do
       notifies :run, 'execute[rebuild-iptables]', :delayed
     end
   else
+    new_resource.lines = "*#{new_resource.table}\n" + new_resource.lines if new_resource.table
     file "/etc/iptables.d/#{new_resource.name}" do
       content new_resource.lines
       mode '0644'


### PR DESCRIPTION
### Description

Allows the user to specify a table for `iptables_rule` when using the `lines` property.  For example:

```
iptables_rule 'http_8080' do
  lines '-A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080'
  table :nat
end
```

### Issues Resolved

https://github.com/chef-cookbooks/iptables/issues/75

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
