### PR TITLE
Resolve deprecation warning

### DIFF
--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -33,7 +33,7 @@ action :enable do
     end
   end
 
-  if lines.nil?
+  if new_resource.lines.nil?
     template "/etc/iptables.d/#{new_resource.name}" do
       source new_resource.source ? new_resource.source : "#{new_resource.name}.erb"
       mode '0644'


### PR DESCRIPTION
### Description

Accessing resource attributes like this has been deprecated and now throws a warning.

```
Deprecated features used!
  rename lines to new_resource.lines at 1 location:
    - /var/chef/cache/cookbooks/iptables/resources/rule.rb:37:in `block in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
```

This change resolves the deprecation warning by making the recommended change.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
