### PR TITLE
Updating namespace for attribute-based rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ end
 To get attribute-driven rules you can (for example) feed a hash of attributes into named iptables.d files like this:
 
 ```ruby
-node.default['iptables']['http_80'] = '-A FWR -p tcp -m tcp --dport 80 -j ACCEPT'
-node.default['iptables']['http_443'] = [
+node.default['iptables']['rules']['http_80'] = '-A FWR -p tcp -m tcp --dport 80 -j ACCEPT'
+node.default['iptables']['rules']['http_443'] = [
   '# an example with multiple lines',
   '-A FWR -p tcp -m tcp --dport 443 -j ACCEPT',
 ]
 
-node['iptables'].map do |rule_name, rule_body|
+node['iptables']['rules'].map do |rule_name, rule_body|
   iptables_rule rule_name do
     lines [ rule_body ].flatten.join("\n")
   end


### PR DESCRIPTION

### Description

The given example for building and looping over attributes to build rules works well, but it also (if unchanged) pulls in the default attributes for iptables, which generate invalid rules.

### Issues Resolved

https://github.com/chef-cookbooks/iptables/issues/81

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jerry Qassar <jqassar@gmail.com>