### PR TITLE
Fix FC108 to resolve test failures

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,9 @@ platforms:
   - name: ubuntu-16.04
     run_list: apt::default
 
+verifier:
+  name: inspec
+
 suites:
   - name: default
     run_list:

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, kind_of: String, name_attribute: true
 property :source, kind_of: String, default: nil
 property :cookbook, kind_of: String, default: nil
 property :variables, kind_of: Hash, default: {}

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,7 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
 if os[:family] == 'redhat'
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /Table: filter/ }

--- a/test/integration/default/inspec/rules_spec.rb
+++ b/test/integration/default/inspec/rules_spec.rb
@@ -1,7 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
 if os[:family] == 'redhat'
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }

--- a/test/integration/disabled/inspec/disabled_spec.rb
+++ b/test/integration/disabled/inspec/disabled_spec.rb
@@ -1,7 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
 if os[:family] == 'redhat'
   describe service('iptables') do
     it { should be_installed }

--- a/test/integration/nested/inspec/default_spec.rb
+++ b/test/integration/nested/inspec/default_spec.rb
@@ -1,13 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
-if os[:family] == 'redhat'
-  describe command('/etc/init.d/iptables status') do
-    its(:stdout) { should match /Table: filter/ }
-  end
-end
-
 # the disable recipe will delete this, but the install should add it back
 describe file('/etc/iptables.d') do
   it { should be_directory }
@@ -25,10 +15,10 @@ end
 
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
-    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
   end
 
   describe file('/etc/sysconfig/ip6tables-config') do
-    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
   end
 end

--- a/test/integration/nested/inspec/rules_spec.rb
+++ b/test/integration/nested/inspec/rules_spec.rb
@@ -1,7 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
 describe iptables do
   it { should have_rule('-A FWR -p tcp -m tcp --dport 22 -j ACCEPT') }
   it { should have_rule('-A FWR -p tcp -m tcp --dport 80 -j ACCEPT') }

--- a/test/integration/no_template/inspec/default_spec.rb
+++ b/test/integration/no_template/inspec/default_spec.rb
@@ -1,6 +1,8 @@
-require 'serverspec'
-
-set :backend, :exec
+if os[:family] == 'redhat'
+  describe command('/etc/init.d/iptables status') do
+    its(:stdout) { should match /Table: filter/ }
+  end
+end
 
 # the disable recipe will delete this, but the install should add it back
 describe file('/etc/iptables.d') do
@@ -19,10 +21,10 @@ end
 
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
-    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
+    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
   end
 
   describe file('/etc/sysconfig/ip6tables-config') do
-    its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
+    its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
   end
 end

--- a/test/integration/no_template/inspec/rules_spec.rb
+++ b/test/integration/no_template/inspec/rules_spec.rb
@@ -1,7 +1,3 @@
-require 'serverspec'
-
-set :backend, :exec
-
 if os[:family] == 'redhat'
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }


### PR DESCRIPTION
### Description

This change allows iptables to pass the Travis test suite once again.
Resolves FC108, introduced in Foodcritic 12.2.0. Trigger a new test of the current master commit to trigger the failure.

### Issues Resolved

No issue yet created.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
