### PR TITLE
Fix inspec test for rhel 7

### DIFF
--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'redhat'
+if os[:family] == 'redhat' && os[:release].start_with?('6')
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /Table: filter/ }
   end

--- a/test/integration/default/inspec/rules_spec.rb
+++ b/test/integration/default/inspec/rules_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'redhat'
+if os[:family] == 'redhat' && os[:release].start_with?('6')
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }
   end


### PR DESCRIPTION
### Description

Rhel 7 can't use init script (systemd compliant), fix inspect tests accordingly

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
