### PR TITLE
Use persistent iptables package for Debian/Ubuntu config

### DIFF
--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -21,4 +21,8 @@ if platform_family?('rhel') && node['platform_version'].to_i == 7
   package 'iptables-services'
 else
   package 'iptables'
+  if platform_family?('debian')
+    # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
+    package 'iptables-persistent'
+  end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -22,12 +22,9 @@ describe 'iptables::default' do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
     end
 
-    it 'should create /etc/network/if-pre-up.d/iptables_load from a template' do
-      expect(chef_run).to create_template('/etc/network/if-pre-up.d/iptables_load')
-    end
-
     it 'should install iptables' do
       expect(chef_run).to install_package('iptables')
+      expect(chef_run).to install_package('iptables-persistent')
       expect(chef_run).to_not install_package('iptables-services')
     end
   end
@@ -37,13 +34,10 @@ describe 'iptables::default' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708').converge(described_recipe)
     end
 
-    it 'should not create /etc/network/if-pre-up.d/iptables_load from a template' do
-      expect(chef_run).to_not create_template('/etc/network/if-pre-up.d/iptables_load')
-    end
-
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
       expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to_not install_package('iptables-persistent')
     end
 
     it 'should enable iptables-services' do

--- a/spec/unit/recipes/disabled_spec.rb
+++ b/spec/unit/recipes/disabled_spec.rb
@@ -14,6 +14,7 @@ describe 'iptables::disabled' do
 
     it 'installs package iptables' do
       expect(chef_run).to install_package('iptables')
+      expect(chef_run).to install_package('iptables-persistent')
       expect(chef_run).to_not install_package('iptables-services')
     end
   end
@@ -26,6 +27,7 @@ describe 'iptables::disabled' do
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
       expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to_not install_package('iptables-persistent')
     end
 
     it 'disables and stops iptables service' do

--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -53,11 +53,8 @@ end
 # Install iptables on a Red Hat or Debian system. Takes the new iptables data.
 def install_rules(data)
   Dir.mkdir('/etc/iptables') unless File.directory?('/etc/iptables')
-  write_iptables('/etc/iptables/general', data)
-  return false unless system('/sbin/iptables-restore < /etc/iptables/general')
-  if File.exist?('/etc/sysconfig/iptables')
-    return false unless system("cp /etc/iptables/general /etc/sysconfig/iptables")
-  end
+  write_iptables("<%= @persisted_file %>", data)
+  return false unless system("/sbin/iptables-restore < <%= @persisted_file %>")
   true
 end
 

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -13,12 +13,6 @@ describe file('/usr/sbin/rebuild-iptables') do
   it { should exist }
 end
 
-if %w(debian ubuntu).include?(os[:family])
-  describe file('/etc/network/if-pre-up.d/iptables_load') do
-    it { should exist }
-  end
-end
-
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
     its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }

--- a/test/integration/nested/inspec/default_spec.rb
+++ b/test/integration/nested/inspec/default_spec.rb
@@ -7,12 +7,6 @@ describe file('/usr/sbin/rebuild-iptables') do
   it { should exist }
 end
 
-if %w(debian ubuntu).include?(os[:family])
-  describe file('/etc/network/if-pre-up.d/iptables_load') do
-    it { should exist }
-  end
-end
-
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
     its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }

--- a/test/integration/no_template/inspec/default_spec.rb
+++ b/test/integration/no_template/inspec/default_spec.rb
@@ -13,12 +13,6 @@ describe file('/usr/sbin/rebuild-iptables') do
   it { should exist }
 end
 
-if %w(debian ubuntu).include?(os[:family])
-  describe file('/etc/network/if-pre-up.d/iptables_load') do
-    it { should exist }
-  end
-end
-
 if %w(redhat fedora).include?(os[:family])
   describe file('/etc/sysconfig/iptables-config') do
     its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }


### PR DESCRIPTION
### Description

- Use package iptables-persistent (https://packages.debian.org/fr/jessie/iptables-persistent) on Ubuntu/Debian for loading rules instead of post network script

- Do not use temporary file:`/etc/iptables/general` for Debian/Ubuntu and only have one file for persisted rule

- Also fix resources/templates accordingly

### Issues Resolved

None but i will solve issue #58 in the next commit by checking consistency of `/etc/sysconfig/iptables` or `/etc/iptables/rules.v4` depending of the system

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
