### PR TITLE
Fix ip6tables restore

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,10 +17,10 @@ platforms:
   - name: debian-8
   - name: debian-9
   - name: fedora-28
-  - name: opensuse-leap-42
+  # - name: opensuse-leap-42 # Fails with timeout after omnibus installation
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-
+  - name: ubuntu-18.04
 suites:
   - name: default
     run_list:

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-if platform_family?('rhel') && node['platform_version'].to_i == 7
+if platform_family?('rhel', 'fedora')
   package 'iptables-services'
 else
   package 'iptables'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,7 +78,6 @@ include_recipe 'iptables::_package'
     service ipt do
       action [:enable, :start]
       supports status: true, start: true, stop: true, restart: true
-      not_if { platform_family?('fedora') }
     end
   end
 end

--- a/recipes/disabled.rb
+++ b/recipes/disabled.rb
@@ -24,7 +24,7 @@ include_recipe 'iptables::_package'
     action [:disable, :stop]
     delayed_action :stop
     supports status: true, start: true, stop: true, restart: true
-    only_if { %w(rhel amazon).include?(node['platform_family']) }
+    only_if { %w(rhel fedora amazon).include?(node['platform_family']) }
   end
 
   # Necessary so that if iptables::disable is used and then later
@@ -38,7 +38,7 @@ include_recipe 'iptables::_package'
   ["/etc/sysconfig/#{ipt}", "/etc/sysconfig/#{ipt}.fallback"].each do |f|
     file f do
       content '# iptables rules files cleared by chef via iptables::disabled'
-      only_if { %w(rhel amazon).include?(node['platform_family']) }
+      only_if { %w(rhel fedora amazon).include?(node['platform_family']) }
       notifies :run, "execute[#{ipt}Flush]", :immediately
     end
   end

--- a/recipes/disabled.rb
+++ b/recipes/disabled.rb
@@ -22,6 +22,7 @@ include_recipe 'iptables::_package'
 %w(iptables ip6tables).each do |ipt|
   service ipt do
     action [:disable, :stop]
+    delayed_action :stop
     supports status: true, start: true, stop: true, restart: true
     only_if { %w(rhel amazon).include?(node['platform_family']) }
   end
@@ -45,6 +46,6 @@ include_recipe 'iptables::_package'
   # Flush and delete iptables rules
   execute "#{ipt}Flush" do
     command "#{ipt} -F"
-    action  :nothing
+    action :nothing
   end
 end

--- a/templates/default/rebuild-iptables.erb
+++ b/templates/default/rebuild-iptables.erb
@@ -54,7 +54,7 @@ end
 def install_rules(data)
   Dir.mkdir('/etc/<%= @ipt %>') unless File.directory?('/etc/<%= @ipt %>')
   write_iptables("<%= @persisted_file %>", data)
-  return false unless system("/sbin/iptables-restore < <%= @persisted_file %>")
+  return false unless system("/sbin/<%= @ipt %>-restore < <%= @persisted_file %>")
   true
 end
 

--- a/test/fixtures/cookbooks/iptables_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/iptables_test/recipes/default.rb
@@ -5,3 +5,7 @@ include_recipe 'iptables::default'
 iptables_rule 'sshd'
 
 iptables_rule6 'sshd'
+
+iptables_rule6 'dhcpv6' do
+  lines '-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT'
+end

--- a/test/integration/default/inspec/rules_spec.rb
+++ b/test/integration/default/inspec/rules_spec.rb
@@ -19,14 +19,8 @@ else
   describe file('/etc/ip6tables.d/dhcpv6') do
     it { should exist }
   end
-  
-  if os[:family] == 'debian'
-    describe command('/sbin/ip6tables-save') do
-      its(:stdout) { should match %r{-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT} }
-    end
-  else
-    describe command('/usr/sbin/ip6tables-save') do
-      its(:stdout) { should match %r{-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT} }
-    end
+
+  describe command('/sbin/ip6tables-save') do
+    its(:stdout) { should match %r{-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT} }
   end
 end

--- a/test/integration/default/inspec/rules_spec.rb
+++ b/test/integration/default/inspec/rules_spec.rb
@@ -19,4 +19,14 @@ else
   describe file('/etc/ip6tables.d/dhcpv6') do
     it { should exist }
   end
+  
+  if os[:family] == 'debian'
+    describe command('/sbin/ip6tables-save') do
+      its(:stdout) { should match %r{-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT} }
+    end
+  else
+    describe command('/usr/sbin/ip6tables-save') do
+      its(:stdout) { should match %r{-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT} }
+    end
+  end
 end

--- a/test/integration/default/inspec/rules_spec.rb
+++ b/test/integration/default/inspec/rules_spec.rb
@@ -15,4 +15,8 @@ else
   describe file('/etc/ip6tables.d/sshd') do
     it { should exist }
   end
+
+  describe file('/etc/ip6tables.d/dhcpv6') do
+    it { should exist }
+  end
 end

--- a/test/integration/disabled/inspec/disabled_spec.rb
+++ b/test/integration/disabled/inspec/disabled_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'redhat'
+if %w(redhat fedora amazon).include?(os[:family])
   describe service('iptables') do
     it { should be_installed }
     it { should_not be_enabled }

--- a/test/integration/disabled/inspec/disabled_spec.rb
+++ b/test/integration/disabled/inspec/disabled_spec.rb
@@ -15,6 +15,9 @@ end
 # "clears" these files out.
 %w(/etc/sysconfig/iptables /etc/sysconfig/iptables.fallback).each do |file|
   describe file(file) do
+    before :each do
+      skip if os[:family] != 'redhat'
+    end
     it { should exist }
     it { should be_file }
     its(:content) { should match(/^# iptables rules files cleared by chef via iptables::disabled$/) }

--- a/test/integration/no_template/inspec/default_spec.rb
+++ b/test/integration/no_template/inspec/default_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'redhat'
+if os[:family] == 'redhat' && os[:release].start_with?('6')
   describe command('/etc/init.d/iptables status') do
     its(:stdout) { should match /Table: filter/ }
   end

--- a/test/integration/no_template/inspec/rules_spec.rb
+++ b/test/integration/no_template/inspec/rules_spec.rb
@@ -1,5 +1,5 @@
 if os[:family] == 'redhat'
-  describe command('/etc/init.d/iptables status') do
+  describe command('/sbin/iptables -nvL') do
     its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }
   end
 else


### PR DESCRIPTION
### Description

* Fixes rebuild-ip(6)tables script failing to restore the generated /etc/sysconfig/ip6tables rule file because it tries to use iptables-restore to load the rules for ip6tables.

* Added a better test case for the above as a rule to allow DHCPv6 as it uses IPv6 addresses (and more importantly prefix length) which will fail if the wrong command is used.

* Massaged the kitchen tests into a somewhat relevant state skipping irrelevant tests on certain platforms as I couldn't get a clean kitchen test.

* Added Ubuntu 18.04 platform to the kitchen config and commented out OpenSUSE as it times out after the omnibus installation with all the versions I tried.

### Issues Resolved

- #32 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
