### PR TITLE
Use value_for_platform to specify different package name for differen…

### DIFF
--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -19,10 +19,10 @@
 
 package 'iptables' do
   package_name value_for_platform(
-    ['centos', 'fedora', 'redhat' ] => {
+    %w(centos fedora redhat) => {
       '>= 7' => 'iptables-services',
       '< 7' => 'iptables'
     },
-    'debian' => { 'default' => 'iptables-persistent' }  # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
+    'debian' => { 'default' => 'iptables-persistent' } # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
   )
 end

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -17,12 +17,12 @@
 # limitations under the License.
 #
 
-if platform_family?('rhel', 'fedora')
-  package 'iptables-services'
-else
-  package 'iptables'
-  if platform_family?('debian')
-    # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
-    package 'iptables-persistent'
-  end
+package 'iptables' do
+  package_name value_for_platform(
+    ['centos', 'fedora', 'redhat' ] => {
+      '>= 7' => 'iptables-services',
+      '< 7' => 'iptables'
+    },
+    'debian' => { 'default' => 'iptables-persistent' }  # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
+  )
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -29,6 +29,22 @@ describe 'iptables::default' do
     end
   end
 
+  context 'rhel 6' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.9').converge(described_recipe)
+    end
+
+    it 'should install iptables' do
+      expect(chef_run).to install_package('iptables')
+      expect(chef_run).to_not install_package('iptables-services')
+      expect(chef_run).to_not install_package('iptables-persistent')
+    end
+
+    it 'should enable iptables' do
+      expect(chef_run).to enable_service('iptables')
+    end
+  end
+
   context 'rhel 7' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708').converge(described_recipe)


### PR DESCRIPTION
…t platform_version.

Signed-off-by: Ali Yahya <amyahya@gmail.com>

### Description

Revert previous change that removed checking platform_version.

### Issues Resolved

- Package name for RHEL 6-based platforms should use `iptables` instead of `iptables-services`

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
