### PR TITLE
Add sensitive option to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ iptables_rule 'http_8080' do
 end
 ```
 
+Additionally, a rule can be marked as sensitive so it's contents does not get output to the the console or logged with the sensitive property set to `true`:
+
+```ruby
+iptables_rule 'http_8080' do
+  lines '-A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080'
+  table :nat
+  sensitive true
+end
+```
+
 To get attribute-driven rules you can (for example) feed a hash of attributes into named iptables.d files like this:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -94,13 +94,22 @@ iptables_rule 'http_8080' do
 end
 ```
 
-Additionally, a rule can be marked as sensitive so it's contents does not get output to the the console or logged with the sensitive property set to `true`:
+Additionally, a rule can be marked as sensitive so it's contents does not get output to the the console or logged with the sensitive property set to `true`. The mode of the generated rule file can be set with the filemode property:
 
 ```ruby
 iptables_rule 'http_8080' do
   lines '-A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080'
   table :nat
   sensitive true
+end
+```
+
+```ruby
+iptables_rule 'http_8080' do
+  lines '-A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080'
+  table :nat
+  sensitive true
+  filemode '0600'
 end
 ```
 

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -24,6 +24,7 @@ property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
 property :ipv6, [TrueClass, FalseClass], default: false
+property :filemode, [String, Integer], default: '0644'
 
 action :enable do
   ipt = new_resource.ipv6 ? 'ip6tables' : 'iptables'
@@ -39,7 +40,7 @@ action :enable do
   if new_resource.lines.nil?
     template "/etc/#{ipt}.d/#{new_resource.name}" do
       source new_resource.source ? new_resource.source : "#{new_resource.name}.erb"
-      mode '0644'
+      mode new_resource.filemode
       cookbook new_resource.cookbook if new_resource.cookbook
       variables new_resource.variables
       backup false
@@ -50,7 +51,7 @@ action :enable do
     new_resource.lines = "*#{new_resource.table}\n" + new_resource.lines if new_resource.table
     file "/etc/#{ipt}.d/#{new_resource.name}" do
       content new_resource.lines
-      mode '0644'
+      mode new_resource.filemode
       backup false
       sensitive new_resource.sensitive
       notifies :run, "execute[rebuild-#{ipt}]", :delayed

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -24,7 +24,6 @@ property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
 property :ipv6, [TrueClass, FalseClass], default: false
-property :sensitive, [TrueClass, FalseClass], default: false
 
 action :enable do
   ipt = new_resource.ipv6 ? 'ip6tables' : 'iptables'

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -24,6 +24,7 @@ property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
 property :ipv6, [TrueClass, FalseClass], default: false
+property :sensitive, [TrueClass, FalseClass], default: false
 
 action :enable do
   ipt = new_resource.ipv6 ? 'ip6tables' : 'iptables'
@@ -43,6 +44,7 @@ action :enable do
       cookbook new_resource.cookbook if new_resource.cookbook
       variables new_resource.variables
       backup false
+      sensitive new_resource.sensitive
       notifies :run, "execute[rebuild-#{ipt}]", :delayed
     end
   else
@@ -51,6 +53,7 @@ action :enable do
       content new_resource.lines
       mode '0644'
       backup false
+      sensitive new_resource.sensitive
       notifies :run, "execute[rebuild-#{ipt}]", :delayed
     end
   end
@@ -70,6 +73,7 @@ action :disable do
   file "/etc/#{ipt}.d/#{new_resource.name}" do
     action :delete
     backup false
+    sensitive new_resource.sensitive
     notifies :run, "execute[rebuild-#{ipt}]", :delayed
   end
 end

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -22,17 +22,17 @@ property :cookbook, String
 property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
+property :sensitive, [TrueClass, FalseClass], default: false
 
 action :enable do
   iptables_rule new_resource.name do
     ipv6 true
-
     source new_resource.source
     cookbook new_resource.cookbook
     variables new_resource.variables
     lines new_resource.lines
     table new_resource.table
-
+    sensitive new_resource.sensitive
     action :enable
   end
 end
@@ -40,13 +40,12 @@ end
 action :disable do
   iptables_rule new_resource.name do
     ipv6 true
-
     source new_resource.source
     cookbook new_resource.cookbook
     variables new_resource.variables
     lines new_resource.lines
     table new_resource.table
-
+    sensitive new_resource.sensitive
     action :disable
   end
 end

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -22,7 +22,6 @@ property :cookbook, String
 property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
-property :sensitive, [TrueClass, FalseClass], default: false
 
 action :enable do
   iptables_rule new_resource.name do

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -22,6 +22,7 @@ property :cookbook, String
 property :variables, Hash, default: {}
 property :lines, String
 property :table, Symbol
+property :filemode, [String, Integer], default: '0644'
 
 action :enable do
   iptables_rule new_resource.name do
@@ -32,6 +33,7 @@ action :enable do
     lines new_resource.lines
     table new_resource.table
     sensitive new_resource.sensitive
+    filemode new_resource.filemode
     action :enable
   end
 end
@@ -45,6 +47,7 @@ action :disable do
     lines new_resource.lines
     table new_resource.table
     sensitive new_resource.sensitive
+    filemode new_resource.filemode
     action :disable
   end
 end

--- a/test/fixtures/cookbooks/iptables_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/iptables_test/recipes/default.rb
@@ -2,9 +2,13 @@ apt_update
 
 include_recipe 'iptables::default'
 
-iptables_rule 'sshd'
+iptables_rule 'sshd' do
+  sensitive true
+end
 
-iptables_rule6 'sshd'
+iptables_rule6 'sshd' do
+  sensitive true
+end
 
 iptables_rule6 'dhcpv6' do
   lines '-A INPUT -d fe80::/10 -p udp -m udp --dport 546 -m state --state NEW -j ACCEPT'


### PR DESCRIPTION
### Description
Senstive resource property added to resources to pass through to underlying template and file resources in rule and rule6 to prevent the contents of rule files being logged or output to the console.

### Issues Resolved
- None

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
