### PR TITLE
Fix error at first run when /usr/sbin/rebuild-iptables not found

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,11 +35,6 @@ end
 include_recipe 'iptables::_package'
 
 %w(iptables ip6tables).each do |ipt|
-  execute "rebuild-#{ipt}" do
-    command "/usr/sbin/rebuild-#{ipt}"
-    action :nothing
-  end
-
   directory "/etc/#{ipt}.d" do
     action :create
   end
@@ -52,6 +47,11 @@ include_recipe 'iptables::_package'
       hashbang: ::File.exist?(system_ruby) ? system_ruby : '/opt/chef/embedded/bin/ruby',
       persisted_file: node['iptables']["persisted_rules_#{ipt}"]
     )
+  end
+
+  execute "rebuild-#{ipt}" do
+    command "/usr/sbin/rebuild-#{ipt}"
+    action :nothing
   end
 
   if platform_family?('debian')


### PR DESCRIPTION
### Description

Fix this error. 
FATAL: Errno::ENOENT: execute[rebuild-iptables] (iptables::default line 38) had an error: Errno::ENOENT: No such file or directory - /usr/sbin/rebuild-iptables

default.rb recipe tries to rebuild iptables when it does not exist.
I just moved rebuild execution after the script creation from the template.