### PR TITLE
Fix a nil safety issue to allow the cookbook to load 

### DIFF
--- a/resources/chain.rb
+++ b/resources/chain.rb
@@ -20,7 +20,7 @@
 
 property :source, String, default: 'iptables.erb'
 property :cookbook, String, default: 'iptables'
-property :config_file, String, default: node['iptables']['persisted_rules_iptables']
+property :config_file, String, default: node['iptables']['persisted_rules_iptables'].to_s
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, [String, Array, Hash]
 property :filemode, [String, Integer], default: '0644'

--- a/resources/chain6.rb
+++ b/resources/chain6.rb
@@ -20,7 +20,7 @@
 
 property :source, String
 property :cookbook, String
-property :config_file, String, default: node['iptables']['persisted_rules_ip6tables']
+property :config_file, String, default: node['iptables']['persisted_rules_ip6tables'].to_s
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, [String, Array, Hash]
 property :filemode, [String, Integer], default: '0644'

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -20,7 +20,7 @@
 
 property :source, String, default: 'iptables.erb'
 property :cookbook, String, default: 'iptables'
-property :config_file, String, default: node['iptables']['persisted_rules_iptables']
+property :config_file, String, default: node['iptables']['persisted_rules_iptables'].to_s
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, String
 property :match, String

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -19,7 +19,7 @@
 
 property :source, String
 property :cookbook, String
-property :config_file, String, default: node['iptables']['persisted_rules_ip6tables']
+property :config_file, String, default: node['iptables']['persisted_rules_ip6tables'].to_s
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, String
 property :match, String


### PR DESCRIPTION
Fix a nil safety issue to allow the cookbook to load at loadtime on unsupported platforms if it's in the dependency tree

Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

### Description

This works around the problem by making the default property valid (an empty string), instead of nil.

### Issues Resolved

#105 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
