### PR TITLE
Fix Chef 12 and Debian support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the iptables cookbook.
 
+## master
+
+- Fix support for Chef 12 (#107)
+- Enhance Debian/Ubuntu support (#103/#104)
+
 ## 6.0.1 (2020-01-08)
 
 - Update readme to require 12.15+ - [@tas50](https://github.com/tas50)
@@ -78,6 +83,7 @@ This file is used to list changes made in each version of the iptables cookbook.
 - specify optional table property for use with lines
 
 ## 4.0.1 (2017-03-29)
+
 - Update metadata to require Chef 12.10+ due to use of with_run_context
 
 ## 4.0.0 (2017-02-27)
@@ -92,11 +98,13 @@ This file is used to list changes made in each version of the iptables cookbook.
 - fixed iptables disabled recipe to flush iptables after disabling the service
 
 ## 3.0.1 (2016-10-10)
+
 - Fix rules resource so rebuild-iptables only runs once
 - Add tests for nested resources
 - Add system ruby attribute so that it can be overridden
 
 ## 3.0.0 (2016-09-16)
+
 - Remove kitchen cloud config
 - Fix default specs to work properly on RHEL and other general spec cleanup
 - Simplify testing and fix failing tests on RHEL
@@ -110,22 +118,28 @@ This file is used to list changes made in each version of the iptables cookbook.
 - Use compat_resource to restore Chef 12.1 - 12.4 compatibility
 
 ## v2.2.0 (2016-02-17)
+
 - Remove the dependency on compat_resource cookbook. This fixes RHEL systems, but increases the required Chef version to 12.5 or later
 
 ## v2.1.1 (2016-01-26)
+
 - Fixed failures on RHEL in the disabled recipe
 
 ## v2.1.0 (2016-01-25)
+
 - Improved compatbility with Fedora
 - Added management of the iptables sysconfig files using 2 new attributes. See the readme for more information
 
 ## v2.0.2 (2016-01-15)
+
 - Fixed rules not being rebuilt when using the disable action in the custom resource
 
 ## v2.0.1 (2015-11-16)
+
 - Added Chefspec matchers
 
 ## v2.0.0 (2015-10-21)
+
 - Migrated LWRP to Chef 12.5 custom resources format with backwards compatibility provided via compat_resource cookbook to 12.X family
 - Added Start / enable of iptables service in the default recipe when on RHEL based systems and the management of /etc/sysconfig/iptables so the service can start
 - Added removal of /etc/iptables.d/ to the disabled recipe to allow for reenabling later on
@@ -133,6 +147,7 @@ This file is used to list changes made in each version of the iptables cookbook.
 - Expanded the serverspec tests and test kitchen suites to better test rules custom resource and disable recipe
 
 ## v1.1.0 (2015-10-05)
+
 - Fixed metadata description of the default recipe
 - Added Kitchen CI config
 - Added Chefspec unit tests
@@ -150,7 +165,9 @@ This file is used to list changes made in each version of the iptables cookbook.
 - Removed pre-Ruby 1.9 hash rockets
 
 ## v1.0.0 (2015-04-29)
+
 NOTE: This release includes breaking changes to the behavior of this cookbook. The iptables_rule definition was converted to a LWRP.  This changes the behavior of disabling iptables rules.  Previously a rule could be disabled by specifying `enable false`.  You must now specify `action :disable`.  Additionally the cookbook no longer installs the out of the box iptables rules.  These were rules made assumptions about the operating environment and should not have been installed out of the box. This makes this recipe a library cookbook that can be better wrapped to meet the needs or your particular environment.
+
 - Definition converted to a LWRP to providing why-run support and
 - The out of the box iptables rules are no longer installed.  If you need these rules you'll need to wrap the cookbook and use the LWRP to define these same rules.
 - Removed all references to the roadmap and deprecation of the cookbook.  It's not going anywhere any time soon
@@ -161,31 +178,40 @@ NOTE: This release includes breaking changes to the behavior of this cookbook. T
 - Included the latest contributing documentation to match the current process
 
 ## v0.14.1 (2015-01-01)
+
 - Fixing File.exists is deprecated for File.exist
 
 ## v0.14.0 (2014-08-31)
+
 - [#14] Adds basic testing suite including Berksfile
 - [#14] Adds basic integration/post-converge tests
 - [#14] Adds default prefix and postfix rules to disalow traffic
 
 ## v0.13.2 (2014-04-09)
+
 - [COOK-4496] Added Amazon Linux support
 
 ## v0.13.0 (2014-03-19)
+
 - [COOK-3927] Substitute Perl version of rebuild-iptables with Ruby version
 
 ## v0.12.2 (2014-03-18)
+
 - [COOK-4411] - Add newling to iptables.snat
 
 ## v0.12.0
+
 - [COOK-2213] - iptables disabled recipe
 
 ## v0.11.0
+
 - [COOK-1883] - add perl package so rebuild script works
 
 ## v0.10.0
+
 - [COOK-641] - be able to save output on rhel-family
 - [COOK-655] - use a template from other cookbooks
 
 ## v0.9.3
+
 - Current public release.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,9 +42,11 @@ case node['platform_family']
 when 'rhel', 'fedora', 'amazon'
   default['iptables']['persisted_rules_iptables'] = '/etc/sysconfig/iptables'
   default['iptables']['persisted_rules_ip6tables'] = '/etc/sysconfig/ip6tables'
+  default['iptables']['packages'] = %w(iptables iptables-services iptables-utils)
 when 'debian'
   default['iptables']['persisted_rules_iptables'] = '/etc/iptables/rules.v4'
   default['iptables']['persisted_rules_ip6tables'] = '/etc/iptables/rules.v6'
+  default['iptables']['packages'] = %w(iptables iptables-persistent)
 end
 
 default['iptables']['persisted_rules_template']['filter'] = {

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -33,9 +33,9 @@ platforms:
        - RUN /usr/bin/yum install libselinux-utils -y
     volumes:
       - /tmp/gitlab-runner-artifacts:/var/gitlab-runner-artifacts
-- name: fedora-30
+- name: fedora-31
   driver:
-    image: dokken/fedora-30
+    image: dokken/fedora-31
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
        - RUN /usr/bin/yum makecache -y -q
@@ -51,7 +51,6 @@ platforms:
        - RUN apt-get update
        - RUN apt-get install rsync -y -q
        - RUN apt-get install selinux-utils -y
-
 - name: debian-10
   driver:
     image: dokken/debian-10

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,7 +19,7 @@ platforms:
   - name: centos-8
   - name: debian-9
   - name: debian-10
-  - name: fedora-latest
+  - name: fedora-31
   - name: ubuntu-16.04
   - name: ubuntu-18.04
 suites:

--- a/libraries/chain.rb
+++ b/libraries/chain.rb
@@ -37,7 +37,7 @@ module Iptables
 
         if chain_definition_valid?(chain)
           chainstring = chain.upcase
-        elsif chain.match?(/^(\w+)$/)
+        elsif !chain.match(/^(\w+)$/).nil?
           chainstring = chain.upcase.concat(' -')
         else
           raise ArgumentError, "Invalid chain format '#{chain}' specified"
@@ -53,8 +53,9 @@ module Iptables
 
     def chain_definition_valid?(chain)
       raise ArgumentError unless chain.is_a?(String)
+
       Chef::Log.info("Validating iptables chain definition: #{chain}")
-      chain.match?(/^((\w+) (-|[a-zA-Z]+))$|^((\w+) (-|[a-zA-Z]+) (\[\d+\:\d+\]))$/)
+      !chain.match(/^((\w+) (-|[a-zA-Z]+))$|^((\w+) (-|[a-zA-Z]+) (\[\d+\:\d+\]))$/).nil?
     end
 
     def chain_exists?(chainhash:, chain:)

--- a/libraries/rule.rb
+++ b/libraries/rule.rb
@@ -20,6 +20,8 @@
 module Iptables
   module RuleHelpers
     def comment_builder(name:, comment:)
+      raise ArgumentError if name.nil? && comment.nil?
+
       int_comment = if comment.is_a?(String)
                       " -m comment --comment \"#{comment}\""
                     elsif comment.is_a?(TrueClass)
@@ -31,8 +33,9 @@ module Iptables
     end
 
     def rule_builder(line: nil, chain: nil, match: nil, target: nil, extra_options: nil)
-      rule = ''
       raise ArgumentError if line.nil? && chain.nil? && match.nil? && target.nil? && extra_options.nil?
+
+      rule = ''
 
       if match.nil? && target.nil?
         rule.concat(line)
@@ -48,7 +51,8 @@ module Iptables
 
     def comment_exists?(rule)
       raise ArgumentError unless rule.is_a?(String)
-      rule.match?(/-m comment --comment/)
+
+      !rule.match(/-m comment --comment/).nil?
     end
   end
 end

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -17,15 +17,4 @@
 # limitations under the License.
 #
 
-# amazon linux, any fedora, and amazon linux 2
-if (platform_family?('rhel') && node['platform_version'].to_i >= 7) ||
-   (platform_family?('amazon') && node['platform_version'].to_i < 2013) ||
-   platform_family?('fedora')
-  package 'iptables-services'
-else
-  package 'iptables'
-  if platform_family?('debian')
-    # Since Ubuntu 10.04LTS and Debian6, this package takes over the automatic loading of the saved iptables rules
-    package 'iptables-persistent'
-  end
-end
+node['iptables']['packages'].each { |pkg| package pkg }

--- a/resources/chain.rb
+++ b/resources/chain.rb
@@ -3,7 +3,7 @@
 # Cookbook:: iptables
 # Resource:: chain
 #
-# Copyright:: 2019, Ben Hughes
+# Copyright:: 2020, Ben Hughes
 # Copyright:: 2017-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ property :cookbook, String, default: 'iptables'
 property :config_file, String, default: lazy { node['iptables']['persisted_rules_iptables'] }
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, [String, Array, Hash]
-property :filemode, [String, Integer], default: '0644'
+property :filemode, [String, Integer], default: '0600'
 
 action :create do
   Chef::Resource::Template.send(:include, Iptables::ChainHelpers)
@@ -40,7 +40,8 @@ action :create do
 
       variables['iptables'][new_resource.table]['chains'] ||= {}
       unless chain_exists?(chainhash: variables['iptables'][new_resource.table]['chains'], chain: new_resource.chain)
-        variables['iptables'][new_resource.table]['chains'].update(chain_builder(chain: new_resource.chain))
+        variables['iptables'][new_resource.table]['chains'] =
+          variables['iptables'][new_resource.table]['chains'].merge(chain_builder(chain: new_resource.chain))
       end
 
       action :nothing

--- a/resources/chain6.rb
+++ b/resources/chain6.rb
@@ -3,7 +3,7 @@
 # Cookbook:: iptables
 # Resource:: chain6
 #
-# Copyright:: 2019, Ben Hughes
+# Copyright:: 2020, Ben Hughes
 # Copyright:: 2017-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,12 +23,12 @@ property :cookbook, String
 property :config_file, String, default: lazy { node['iptables']['persisted_rules_ip6tables'] }
 property :table, String, equal_to: %w(filter mangle nat raw security), default: 'filter'
 property :chain, [String, Array, Hash]
-property :filemode, [String, Integer], default: '0644'
+property :filemode, [String, Integer], default: '0600'
 
 action :create do
   iptables_chain new_resource.name do
-    source new_resource.source
-    cookbook new_resource.cookbook
+    source new_resource.source if new_resource.source
+    cookbook new_resource.cookbook if new_resource.cookbook
     config_file new_resource.config_file
     table new_resource.table
     chain new_resource.chain

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -3,7 +3,7 @@
 # Cookbook:: iptables
 # Resource:: rule
 #
-# Copyright:: 2019, Ben Hughes
+# Copyright:: 2020, Ben Hughes
 # Copyright:: 2017-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ property :target, String
 property :line, String
 property :comment, [String, TrueClass, FalseClass], default: true
 property :extra_options, String
-property :filemode, [String, Integer], default: '0644'
+property :filemode, [String, Integer], default: '0600'
 
 action :create do
   Chef::Resource::Template.send(:include, Iptables::RuleHelpers)

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -3,7 +3,7 @@
 # Cookbook:: iptables
 # Resource:: rule6
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2020, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ property :target, String
 property :line, String
 property :comment, [String, TrueClass, FalseClass], default: true
 property :extra_options, String
-property :filemode, [String, Integer], default: '0644'
+property :filemode, [String, Integer], default: '0600'
 
 action :create do
   iptables_rule new_resource.name do
-    source new_resource.source
-    cookbook new_resource.cookbook
+    source new_resource.source if new_resource.source
+    cookbook new_resource.cookbook if new_resource.cookbook
     config_file new_resource.config_file
     table new_resource.table
     chain new_resource.chain

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'iptables::default' do
   context 'Debian' do
-    cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'debian', version: '9').converge(described_recipe)
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'debian', version: '9').converge(described_recipe)
     end
 
     it 'should install iptables' do
@@ -12,26 +12,18 @@ describe 'iptables::default' do
       expect(chef_run).to_not install_package('iptables-services')
     end
 
-    %w(iptables ip6tables).each do |ipt|
-      it 'should create reload resource' do
-        reload_exec = chef_run.execute("reload #{ipt}")
-        expect(reload_exec).to do_nothing
-      end
-    end
-
-    it 'should add supporting files' do
-      expect(chef_run).to create_template('/etc/network/if-pre-up.d/iptables_load')
-      expect(chef_run).to create_template('/etc/network/if-pre-up.d/ip6tables_load')
+    it 'should enable netfilter-persistent' do
+      expect(chef_run).to enable_service('netfilter-persistent')
     end
   end
 
   context 'RHEL 6' do
-    cached(:chef_run) do
+    let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.9').converge(described_recipe)
     end
 
     it 'should install iptables' do
-      expect(chef_run).to_not install_package('iptables-services')
+      expect(chef_run).to install_package('iptables-services')
       expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
@@ -50,12 +42,12 @@ describe 'iptables::default' do
   end
 
   context 'Amazon 2018' do
-    cached(:chef_run) do
+    let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'amazon', version: '2018').converge(described_recipe)
     end
 
     it 'should install iptables' do
-      expect(chef_run).to_not install_package('iptables-services')
+      expect(chef_run).to install_package('iptables-services')
       expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
@@ -74,13 +66,13 @@ describe 'iptables::default' do
   end
 
   context 'RHEL 7' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.6.1804').converge(described_recipe)
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.7.1908').converge(described_recipe)
     end
 
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
-      expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
 
@@ -98,13 +90,13 @@ describe 'iptables::default' do
   end
 
   context 'Amazon 2' do
-    cached(:chef_run) do
+    let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge(described_recipe)
     end
 
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
-      expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
 
@@ -122,13 +114,13 @@ describe 'iptables::default' do
   end
 
   context 'Fedora' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'fedora', version: '29').converge(described_recipe)
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'fedora', version: '30').converge(described_recipe)
     end
 
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
-      expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
 

--- a/spec/unit/recipes/disabled_spec.rb
+++ b/spec/unit/recipes/disabled_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'iptables::disabled' do
   context 'Debian' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'debian', version: '9').converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'debian', version: '9').converge(described_recipe)
     end
 
     it 'installs package iptables' do
@@ -22,12 +22,12 @@ describe 'iptables::disabled' do
 
   context 'RHEL 7' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'centos', version: '7.6.1804').converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.7.1908').converge(described_recipe)
     end
 
     it 'should install iptables-services' do
       expect(chef_run).to install_package('iptables-services')
-      expect(chef_run).to_not install_package('iptables')
+      expect(chef_run).to install_package('iptables')
       expect(chef_run).to_not install_package('iptables-persistent')
     end
 
@@ -37,9 +37,8 @@ describe 'iptables::disabled' do
         expect(reload_exec).to do_nothing
       end
 
-      it 'should create fallback files' do
+      it 'should clear rule file' do
         expect(chef_run).to create_file("/etc/sysconfig/#{ipt}")
-        expect(chef_run).to create_file("/etc/sysconfig/#{ipt}.fallback")
       end
     end
 

--- a/templates/default/iptables_load.erb
+++ b/templates/default/iptables_load.erb
@@ -1,3 +1,0 @@
-#!/bin/sh
-<%= @iptables_restore_binary %> < <%= @iptables_save_file %>
-exit 0

--- a/test/fixtures/cookbooks/iptables_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/iptables_test/recipes/default.rb
@@ -1,4 +1,4 @@
-apt_update
+apt_update ''
 
 include_recipe 'iptables::default'
 

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,17 +1,24 @@
-if os[:family] == 'redhat' && os[:release].start_with?('6')
-  describe command('/etc/init.d/iptables status') do
-    its(:stdout) { should match /Table: filter/ }
+case os.family
+when 'redhat'
+  if os[:release].start_with?('6')
+    describe command('/etc/init.d/iptables status') do
+      its(:stdout) { should match /Table: filter/ }
+    end
   end
-end
 
-%w(iptables ip6tables).each do |variant|
-  if %w(debian ubuntu).include?(os[:family])
-    describe file("/etc/network/if-pre-up.d/#{variant}_load") do
+  %w(iptables ip6tables).each do |variant|
+    describe file("/etc/sysconfig/#{variant}") do
       it { should exist }
     end
-  elsif %w(redhat fedora).include?(os[:family])
     describe file("/etc/sysconfig/#{variant}-config") do
+      it { should exist }
       its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    end
+  end
+when 'debian', 'ubuntu'
+  %w(v4 v6).each do |variant|
+    describe file("/etc/iptables/rules.#{variant}") do
+      it { should exist }
     end
   end
 end

--- a/test/integration/disabled/inspec/disabled_spec.rb
+++ b/test/integration/disabled/inspec/disabled_spec.rb
@@ -1,19 +1,30 @@
-if %w(redhat fedora amazon).include?(os[:family])
+case os.family
+when 'redhat', 'fedora', 'amazon'
   describe service('iptables') do
     it { should be_installed }
     it { should_not be_enabled }
     it { should_not be_running }
   end
-end
-# some RHEL/CentOS versions use these files to persist rules. disable recipe
-# "clears" these files out.
-%w(/etc/sysconfig/iptables /etc/sysconfig/iptables.fallback).each do |file|
-  describe file(file) do
-    before :each do
-      skip if os[:family] != 'redhat'
+
+  %w(iptables ip6tables).each do |file|
+    describe file("/etc/sysconfig/#{file}") do
+      it { should exist }
+      it { should be_file }
+      its(:content) { should match(/^# iptables rules files cleared by chef via iptables::disabled$/) }
     end
-    it { should exist }
-    it { should be_file }
-    its(:content) { should match(/^# iptables rules files cleared by chef via iptables::disabled$/) }
+  end
+when 'debian', 'ubuntu'
+  describe service('netfilter-persistent') do
+    it { should be_installed }
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+
+  %w(v4 v6).each do |variant|
+    describe file("/etc/iptables/rules.#{variant}") do
+      it { should exist }
+      it { should be_file }
+      its(:content) { should match(/^# iptables rules files cleared by chef via iptables::disabled$/) }
+    end
   end
 end

--- a/test/integration/nested/inspec/default_spec.rb
+++ b/test/integration/nested/inspec/default_spec.rb
@@ -1,11 +1,14 @@
-%w(iptables ip6tables).each do |variant|
-  if %w(debian ubuntu).include?(os[:family])
-    describe file("/etc/network/if-pre-up.d/#{variant}_load") do
-      it { should exist }
-    end
-  elsif %w(redhat fedora).include?(os[:family])
+case os.family
+when 'redhat', 'fedora'
+  %w(iptables ip6tables).each do |variant|
     describe file("/etc/sysconfig/#{variant}-config") do
       its(:content) { should match(/IPTABLES_STATUS_VERBOSE="yes"/) }
+    end
+  end
+when 'debian', 'ubuntu'
+  %w(v4 v6).each do |variant|
+    describe file("/etc/iptables/rules.#{variant}") do
+      it { should exist }
     end
   end
 end

--- a/test/integration/no_template/inspec/default_spec.rb
+++ b/test/integration/no_template/inspec/default_spec.rb
@@ -1,17 +1,20 @@
-if os[:family] == 'redhat' && os[:release].start_with?('6')
-  describe command('/etc/init.d/iptables status') do
-    its(:stdout) { should match /Table: filter/ }
-  end
-end
-
-%w(iptables ip6tables).each do |variant|
-  if %w(debian ubuntu).include?(os[:family])
-    describe file("/etc/network/if-pre-up.d/#{variant}_load") do
-      it { should exist }
+case os.family
+when 'redhat', 'fedora'
+  if os[:release].start_with?('6')
+    describe command('/etc/init.d/iptables status') do
+      its(:stdout) { should match /Table: filter/ }
     end
-  elsif %w(redhat fedora).include?(os[:family])
+  end
+
+  %w(iptables ip6tables).each do |variant|
     describe file("/etc/sysconfig/#{variant}-config") do
       its(:content) { should match /IPTABLES_STATUS_VERBOSE="yes"/ }
+    end
+  end
+when 'debian', 'ubuntu'
+  %w(v4 v6).each do |variant|
+    describe file("/etc/iptables/rules.#{variant}") do
+      it { should exist }
     end
   end
 end

--- a/test/integration/no_template/inspec/rules_spec.rb
+++ b/test/integration/no_template/inspec/rules_spec.rb
@@ -1,9 +1,12 @@
-if os[:family] == 'redhat'
-  describe command('/sbin/iptables -nvL') do
-    its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }
-  end
-else
-  describe iptables do
-    it { should have_rule('-A FWR -p tcp -m tcp --dport 22 -m comment --comment sshd -j ACCEPT') }
-  end
+# if os[:family] == 'redhat'
+#   describe command('/sbin/iptables -nvL') do
+#     its(:stdout) { should match /ACCEPT.*tcp dpt:22/ }
+#   end
+# else
+#   describe iptables do
+#     it { should have_rule('-A FWR -p tcp -m tcp --dport 22 -m comment --comment sshd -j ACCEPT') }
+#   end
+# end
+describe iptables do
+  it { should have_rule('-A FWR -p tcp -m tcp --dport 22 -m comment --comment sshd -j ACCEPT') }
 end


### PR DESCRIPTION
### Description

1. Fix missing method in Chef 12. Fixes #107
2. Enhance Debian/Ubuntu support and replace pre if-up hooks with netfilter-persistent. Should fix #103 and #104.
3. General robustness improvements.

### Issues Resolved

- #103 
- #104 
- #107 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
