### PR TITLE
Expand allowed data types for rule properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is used to list changes made in each version of the iptables cookbook.
 
 - resolved cookstyle error: recipes/default.rb:19:14 warning: `Lint/SendWithMixinArgument`
 - Fixes issue where comments with a space were not quoted and would cause iptables to fail to start
+- Allow the use of String for rule `:ip_Version` - [@bmhughes](https://github.com/bmhughes)
+- Allow the use of String and Integer for rule `:protocol` - [@bmhughes](https://github.com/bmhughes)
 
 ## 7.0.0 (2020-02-18)
 

--- a/documentation/iptables_rule.md
+++ b/documentation/iptables_rule.md
@@ -22,8 +22,8 @@ If the property `line` is used all other properties around configuring the iptab
 --------------------------------- | ----------- | -------- | ----------- | -------------- |
 | `table`              | `Symbol`       | `:filter` | The table the chain exists on for the rule | `:filter`, `:mangle`, `:nat`, `:raw`, `:security` |
 | `chain`         | `Symbol`      | `nil` | The name of the Chain to put this rule on | |
-| `ip_version`                  | `Symbol`      | `:ipv4` | The IP version | `:ipv4`, `:ipv6` |
-| `protocol`                  | `Symbol`      | | The protocol to look for | |
+| `ip_version`                  | `Symbol`, `String`      | `:ipv4` | The IP version | `:ipv4`, `:ipv6`, `ipv4`, `ipv6` |
+| `protocol`                  | `Symbol`, `String`, `Integer`      | | The protocol to look for | |
 | `match`                  | `String`      | | extended packet matching module to use | |
 | `source`                  | `String`      | | Source specification. Address can be either a network name, a hostname (please note that specifying any name to be resolved with a remote query such as DNS is a really bad idea), a network IP address (with /mask), or a plain IP address. The mask can be either a network mask or a plain number, specifying the number of 1's at the left side of the network mask. Thus, a mask of 24 is equivalent to 255.255.255.0. A "!" argument before the address specification inverts the sense of the address. | |
 | `destination`                  | `String`      | | Destination specification,  Address can be either a network name, a hostname (please note that specifying any name to be resolved with a remote query such as DNS is a really bad idea), a network IP address (with /mask), or a plain IP address. The mask can be either a network mask or a plain number, specifying the number of 1's at the left side of the network mask. Thus, a mask of 24 is equivalent to 255.255.255.0. A "!" argument before the address specification inverts the sense of the address. | |

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -8,12 +8,12 @@ property :table, [Symbol, String],
 property :chain, [Symbol, String],
           description: 'The name of the Chain to put this rule on'
 
-property :ip_version, Symbol,
-          equal_to: %i(ipv4 ipv6),
+property :ip_version, [Symbol, String],
+          equal_to: [:ipv4, :ipv6, 'ipv4', 'ipv6'],
           default: :ipv4,
           description: 'The IP version, 4 or 6'
 
-property :protocol, Symbol, #--protocol (-p)
+property :protocol, [Symbol, String, Integer], #--protocol (-p)
           description: 'The protocol of the rule or of the packet to check. The specified protocol can be one of :tcp, :udp, :icmp, or :all, or it can be a numeric value, representing one of these protocols or a different one. A protocol name from /etc/protocols is also allowed. A "!" argument before the protocol inverts the test. The number zero is equivalent to all. Protocol all will match with all protocols and is taken as default when this option is omitted. '
 
 property :match, String, # --match (-m)
@@ -76,7 +76,7 @@ property :sensitive, [true, false],
           description: 'mark the resource as senstive'
 
 property :config_file, String,
-          default: lazy { default_iptables_rules_file(ip_version) },
+          default: lazy { default_iptables_rules_file(ip_version.to_sym) },
           description: 'The full path to find the rules on disk'
 
 deprecated_property_alias 'target', 'jump', 'The target property was renamed jump in 7.0.0 and will be removed in 8.0.0'

--- a/resources/rule6.rb
+++ b/resources/rule6.rb
@@ -8,12 +8,12 @@ property :table, [Symbol, String],
 property :chain, [Symbol, String],
           description: 'The name of the Chain to put this rule on'
 
-property :ip_version, Symbol,
-          equal_to: %i(ipv4 ipv6),
+property :ip_version, [Symbol, String],
+          equal_to: [:ipv4, :ipv6, 'ipv4', 'ipv6'],
           default: :ipv6,
           description: 'The IP version, 4 or 6'
 
-property :protocol, Symbol, #--protocol (-p)
+property :protocol, [Symbol, String, Integer], #--protocol (-p)
           description: 'The protocol of the rule or of the packet to check. The specified protocol can be one of :tcp, :udp, :icmp, or :all, or it can be a numeric value, representing one of these protocols or a different one. A protocol name from /etc/protocols is also allowed. A "!" argument before the protocol inverts the test. The number zero is equivalent to all. Protocol all will match with all protocols and is taken as default when this option is omitted. '
 
 property :match, String, # --match (-m)

--- a/test/cookbooks/test/recipes/rule-line-number.rb
+++ b/test/cookbooks/test/recipes/rule-line-number.rb
@@ -22,7 +22,7 @@ end
 iptables_rule 'Allow from loopback interface' do
   table :filter
   chain :INPUT
-  ip_version :ipv4
+  ip_version 'ipv4'
   jump 'ACCEPT'
   in_interface 'eth0'
   line_number 1

--- a/test/cookbooks/test/recipes/rules.rb
+++ b/test/cookbooks/test/recipes/rules.rb
@@ -21,6 +21,13 @@ iptables_rule 'Divert tcp prerouting' do
   jump 'DIVERT'
 end
 
+iptables_rule 'Accept ICMP' do
+  chain :INPUT
+  ip_version 'ipv4'
+  protocol 'icmp'
+  jump 'ACCEPT'
+end
+
 iptables_rule 'Mark Diverted rules' do
   table :mangle
   chain :DIVERT

--- a/test/integration/rules/rules_spec.rb
+++ b/test/integration/rules/rules_spec.rb
@@ -3,6 +3,7 @@ describe command('/sbin/iptables-save') do
   its(:stdout) { should match /:INPUT\sACCEPT\s\[\d+\:\d+\]/ }
   its(:stdout) { should match /:OUTPUT\sACCEPT\s\[\d+\:\d+\]/ }
   its(:stdout) { should match /:FORWARD\sACCEPT\s\[\d+\:\d+\]/ }
+  its(:stdout) { should match /-A INPUT -p icmp -j ACCEPT/ }
 
   its(:stdout) { should match /\*mangle/ }
   its(:stdout) { should match /:INPUT\sACCEPT\s\[\d+\:\d+\]/ }


### PR DESCRIPTION
### Description

- Allow `rule.ip_version` to accept a symbol or string
- Allow `rule.protocol` to accept a symbol/string/integer

The current rule resource can't be trivially wrapped from role node attributes as you need to pass a symbol to `ip_version` and `protocol`, also protocol numbers are unable to be used.

As the resulting string is built from string interpolation anyway I can't see an issue in allowing more data types to be used.

### Issues Resolved

- n/a

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
