### PR TITLE
Comments with Spaces cause failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the iptables cookbook.
 ## Unreleased
 
 - resolved cookstyle error: recipes/default.rb:19:14 warning: `Lint/SendWithMixinArgument`
+- Fixes issue where comments with a space were not quoted and would cause iptables to fail to start
 
 ## 7.0.0 (2020-02-18)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,12 +3,11 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Installs the iptables daemon and provides resources for managing rules'
-version           '7.0.0'
+source_url        'https://github.com/chef-cookbooks/iptables'
+issues_url        'https://github.com/chef-cookbooks/iptables/issues'
 chef_version      '>= 14'
+version           '7.0.1'
 
 %w(redhat centos debian ubuntu amazon scientific oracle amazon zlinux).each do |os|
   supports os
 end
-
-source_url 'https://github.com/chef-cookbooks/iptables'
-issues_url 'https://github.com/chef-cookbooks/iptables/issues'

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -106,7 +106,7 @@ action :create do
     rule << " -o #{new_resource.out_interface}" if new_resource.out_interface
     rule << " -f #{new_resource.fragment}" if new_resource.fragment
     rule << " #{new_resource.extra_options}" if new_resource.extra_options
-    rule << " -m comment --comment #{new_resource.comment}" if new_resource.comment
+    rule << " -m comment --comment \"#{new_resource.comment}\"" if new_resource.comment
   end
 
   with_run_context :root do

--- a/test/cookbooks/test/recipes/rules.rb
+++ b/test/cookbooks/test/recipes/rules.rb
@@ -35,3 +35,12 @@ iptables_rule 'accept divert trafic' do
   ip_version :ipv4
   jump 'ACCEPT'
 end
+
+iptables_rule 'Rule with space in comment' do
+  table :filter
+  comment 'This will allow loopback'
+  chain :INPUT
+  ip_version :ipv4
+  jump 'ACCEPT'
+  in_interface 'lo'
+end


### PR DESCRIPTION
### Description

Fixes issue where comments with a space were not quoted and would cause iptables to fail to start
- Fixed rule resource
- Added test to ensure it will not break again

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>