### PR TITLE
Resolve undefined method `new_resource' error (Fixes #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the iptables cookbook.
 
+## UNRELEASED
+
+- Resolved error: `resources/service.rb:65` undefined method `new_resource' for Chef::Resource::Service (Fixes [#129](https://github.com/chef-cookbooks/iptables/issues/129))
+
 ## 7.1.0 (2020-06-09)
 
 - Resolved cookstyle error: recipes/default.rb:19:14 warning: `Lint/SendWithMixinArgument`

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -61,7 +61,7 @@ action :enable do
       )
     end
     with_run_context :root do
-      edit_resource(:service, new_resource.service_name) do
+      edit_resource(:service, new_resource.service_name) do |new_resource|
         subscribes :restart, "template[#{new_resource.config_file}]", :delayed
         action [:enable, :start]
       end


### PR DESCRIPTION
### Description

Resolve error: `resources/service.rb:65` undefined method `new_resource' for Chef::Resource::Service which prevents usage of the `iptables_service` resource

### Issues Resolved

- #129 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>