### PR TITLE
WIP:Allow creating rules without specifying exact line numbers

### DIFF
--- a/templates/default/iptables.erb
+++ b/templates/default/iptables.erb
@@ -12,15 +12,15 @@ next table and so on
 <% unless @iptables.nil? || @iptables.empty? -%>
 <% @iptables.each do |table, data| -%>
 *<%= table %>
-<%# Put the chains in the file, format of :Name%>
+<%# Put the chains in the file, format of :Name %>
 <% unless data['chains'].nil? || data['chains'].empty? -%>
 <% data['chains'].each do |chain, value| -%>
 :<%= chain %> <%= value %>
 <% end -%>
 <% end -%>
-<%# once all chains are down we put the rules doen%>
+<%# once all chains are down we put the rules down %>
 <% unless data['rules'].nil? || data['rules'].empty? -%>
-<% data['rules'].each do |rule| -%>
+<% data['rules'].reject{|rule| rule.to_s.empty? }.each do |rule| -%>
 <%= rule %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Adds a feature whereby `iptables_rules` can be added without specifying the exact line number and they will be placed at the next available line, I.E. at the end of the current rules. This makes it easier when you just want to specify the rules in order, from multiple recipes in the run-list

### Issues Resolved
- #131 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>